### PR TITLE
Update https.md

### DIFF
--- a/docs/config/https.md
+++ b/docs/config/https.md
@@ -36,6 +36,18 @@ If using a Docker container, this folder is `/data` within the container. If you
    }
    ```
 
+If using MacOS/*nix based systems
+in terminal paste the following. This will create the `config.json` in the current directory
+```zsh
+cat <<"EOF" | tee config.json
+{
+  "https": {
+    "key": "/data/selfhost.key",
+    "cert": "/data/selfhost.crt"
+  }
+}
+EOF
+```
 ### Configuring with environment variables:
 If you can’t easily create new files, you can also configure HTTPS using environment variables. Set the `ACTUAL_HTTPS_KEY` and `ACTUAL_HTTPS_CERT` environment variables to the contents of the `.key` and `.crt` files, respectively. If you’re unable to include newlines in the environment variable values, you can replace any newlines with `\n` and Actual will automatically convert them back to newlines.
 


### PR DESCRIPTION
Add instructions for creating the config.json via a single terminal command. 

Reasoning - Assisted a MacOS deploy where they had everything setup correctly but when they made the config.json file their instance crashed, this was due to using the default GUI text editor which saved the file as a .rtf and they renamed to .json. Doing this will leave metadata in the file and actual wont know what to do with it causing an infinite restart loop. 

This addition provides a simple method to create the file without the possibility of extra formatting bits causing issues